### PR TITLE
풀이: 백준.1935.후위 표기식2

### DIFF
--- a/problems/baekjoon/1935/changi.cpp
+++ b/problems/baekjoon/1935/changi.cpp
@@ -1,0 +1,68 @@
+#include <algorithm>
+#include <iostream>
+#include <stack>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+double table['Z' - 'A' + 1];
+
+void solution() {
+  int N;
+  string line;
+
+  cin >> N;
+  cin >> line;
+
+  for (int i = 0; i < N; i++) {
+    cin >> table[i];
+  }
+
+  stack<double> num;
+
+  for (char c : line) {
+    if ('A' <= c && c <= 'Z') {
+      num.push(table[c - 'A']);
+      continue;
+    }
+
+    double first, second;
+    first = num.top();
+    num.pop();
+    second = num.top();
+    num.pop();
+    switch (c) {
+      case '+': {
+        num.push(first + second);
+        break;
+      }
+      case '-': {
+        num.push(second - first);
+        break;
+      }
+      case '*': {
+        num.push(first * second);
+        break;
+      }
+      case '/': {
+        num.push(second / first);
+        break;
+      }
+    }
+  }
+
+  cout << num.top() << "\n";
+}
+
+int main() {
+  ios_base ::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
+  cout << fixed;
+  cout.precision(2);
+
+  solution();
+
+  return 0;
+}


### PR DESCRIPTION
# 1935. 후위 표기식2

issue: #1 

[링크](https://www.acmicpc.net/problem/1935)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   43.083    |

## 설계

### 시간복잡도

후위표기식은 최대 100글자 까지 이므로 시간복잡도는 O(100) 이다. 이는 제한시간 내에 충분하다.

### 공간복잡도

소숫점까지 계산을 해야 하므로 double 형을 선언한다.

최악의 경우 스택에 100개의 double형의 숫자가 들어갈 수 있다. 이는 메모리 제한에 큰 영향을 주지 않는다.

알파벳을 숫자로 치환하기 위해 알파벳 테이블을 선언한다. 알파벳에 해당하는 값은 정수이고 크기 제한이 주어지지 않으므로 int형으로 선언한다. 

(만약의 경우를 대비해 long long 형으로 선언하는것도 좋은 방법)

### 스택을 이용

우선순위에 따른 식을 계산하기 위해선 중위 표기식을 후위 표기식으로 바꿀 필요가 존재한다.

후위표기식으로 표현된 경우 스택을 이용해 바로 계산할 수 있다.

- 연산자 기호가 아닌경우 : 숫자를 push
- 연산자 기호인경우 : 맨 위 숫자와 그 다음 숫자를 pop하고 그 두 수를 연산후 push

## 정리

| 내 코드 (ms) | 빠른 코드 (ms) |
| :----------: | :------------: |
|      0       |       0        |

## 고생한 점
