### PR TITLE
풀이: 백준.1918.후위 표기식

### DIFF
--- a/problems/baekjoon/1918/changi.cpp
+++ b/problems/baekjoon/1918/changi.cpp
@@ -1,0 +1,68 @@
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <stack>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+void solution() {
+  string line;
+  string answer = "";
+  stack<char> s;
+  map<char, int> icp;  // stack 외부 우선순위
+  map<char, int> isp;  // stack 내부 우선순위
+
+  icp['+'] = isp['+'] = icp['-'] = isp['-'] = 1;
+  icp['*'] = isp['*'] = icp['/'] = isp['/'] = 2;
+  icp['('] = 3;
+  isp['('] = 0;
+
+  cin >> line;
+
+  for (char c : line) {
+    if ('A' <= c && c <= 'Z') {
+      answer += c;
+      continue;
+    }
+
+    switch (c) {
+      case ')': {
+        while (!s.empty() && s.top() != '(') {
+          answer += s.top();
+          s.pop();
+        }
+        // 남아있는 '(' 를 비워줌
+        s.pop();
+      } break;
+      default: {
+        // 현재 들어갈 연산자가 stack의 top보다 우선순위가 높을 때까지 반복
+        while (!s.empty() && isp[s.top()] >= icp[c]) {
+          if (s.top() != '(') {
+            answer += s.top();
+          }
+          s.pop();
+        }
+        s.push(c);
+      }
+    }
+  }
+
+  while (!s.empty()) {
+    answer += s.top();
+    s.pop();
+  }
+
+  cout << answer << "\n";
+}
+
+int main() {
+  ios_base ::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
+
+  solution();
+
+  return 0;
+}


### PR DESCRIPTION
# 1918. 후위 표기식

[링크](https://www.acmicpc.net/problem/1918)

| 난이도  | 정답률(\_%) |
| :-----: | :---------: |
| Gold IV |   30.897    |

## 설계

### 시간 복잡도

표기식을 변경하는 것은 O(N)번만에 가능하다.

변형할 중위 표기식은 길이가 최대 100 이므로 제한시간 1초 내에 충분하다.

### 공간 복잡도

입력받는 표기식에서 숫자는 나타나지 않으므로 숫자 형태가 아닌 문자 형태로 충분하다.

### stack을 이용

중위 표기식의 경우 stack을 이용해 후위 표기식으로 변경이 가능하다.

우선 각 연산별로 우선순위를 부여한다 (높을수록 우선순위가 높음)

| 연산자 | stack내부에서 우선순위 | stack외부에서 우선순위 |
| :----: | :--------------------: | :--------------------: |
|  +,-   |           1            |           1            |
|  \*,/  |           2            |           2            |
|   (    |           0            |           3            |
|   )    |          NULL          |          NULL          |

)의 경우 NULL인 이유는 )은 stack에 저장되지 않기 때문이다.

중위 표기식을 순회하며 다음과 같은 조건으로 후위 표기식을 완성한다.

- 숫자인 경우 바로 answer에 덧붙임
- 연산자인 경우 stack의 top과 현재연산자의 우선순위에 따라 분기처리한다
  - 현재 연산자가 top보다 우선순위가 높음
    - stack에 push
  - 현재 연산자가 top보다 우선순위가 낮음
    - 현재 연산자가 우선순위가 높아질 때까지 stack pop
    - pop한 연산자는 answer에 덧붙임

이 때 스택이 비어있는 경우에 대한 처리가 필요하다.

```cpp
// 연산자인 경우
switch (c) {
  case ')': {
    while (!s.empty() && s.top() != '(') {
      answer += s.top();
      s.pop();
    }
    // 남아있는 '(' 를 비워줌
    s.pop();
  } break;
  default: {
    // 현재 들어갈 연산자가 stack의 top보다 우선순위가 높을 때까지 반복
    while (!s.empty() && isp[s.top()] >= icp[c]) {
      if (s.top() != '(') {
        answer += s.top();
      }
      s.pop();
    }
    s.push(c);
  }
}
```

## 정리

| 내 코드 (ms) | 빠른 코드 (ms) |
| :----------: | :------------: |
|      0       |       0        |

## 고생한 점
