### PR TITLE
Solved: 백준_시간초과

### DIFF
--- a/problems/baekjoon/11332/sujeong.java
+++ b/problems/baekjoon/11332/sujeong.java
@@ -1,0 +1,67 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.math.BigInteger;
+
+public class Main {
+    private static final String FAIL = "TLE!\n";
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int testCase = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < testCase; i++) {
+            String[] situation = br.readLine().split(" ");
+            String bigO = situation[0];
+            BigInteger inputLength = new BigInteger(situation[1]);
+            BigInteger executeCount = new BigInteger(situation[2]);
+            BigInteger timeLimit = BigInteger.valueOf(Integer.parseInt(situation[3]) * 100000000);
+
+            if (bigO.equals("O(N)")) {
+                if (inputLength.multiply(executeCount).compareTo(timeLimit) == 1) {
+                    bw.write(FAIL);
+                    continue;
+                }
+            } else if (bigO.equals("O(N^2)")) {
+                if (inputLength.pow(2).multiply(executeCount).compareTo(timeLimit) == 1) {
+                    bw.write(FAIL);
+                    continue;
+                }
+            } else if (bigO.equals("O(N^3)")) {
+                if (inputLength.pow(3).multiply(executeCount).compareTo(timeLimit) == 1) {
+                    bw.write(FAIL);
+                    continue;
+                }
+            } else if (bigO.equals("O(2^N)")) {
+                BigInteger base = new BigInteger("2");
+                if (base.pow(inputLength.intValue()).multiply(executeCount).compareTo(timeLimit) == 1) {
+                    bw.write(FAIL);
+                    continue;
+                }
+            } else {
+                int n = inputLength.intValue();
+
+                while (n-- > 1) {
+                    inputLength = inputLength.multiply(new BigInteger(Integer.toString(n)));
+                    if (inputLength.compareTo(timeLimit) == 1) {
+                        break;
+                    }
+                }
+
+                if (inputLength.multiply(executeCount).compareTo(timeLimit) == 1) {
+                    bw.write(FAIL);
+                    continue;
+                }
+            }
+
+            bw.write("May Pass.\n");
+        }
+
+        bw.flush();
+        bw.close();
+    }
+}

--- a/problems/baekjoon/11332/sujeong.java
+++ b/problems/baekjoon/11332/sujeong.java
@@ -6,8 +6,6 @@ import java.io.OutputStreamWriter;
 import java.math.BigInteger;
 
 public class Main {
-    private static final String FAIL = "TLE!\n";
-
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
@@ -16,52 +14,65 @@ public class Main {
 
         for (int i = 0; i < testCase; i++) {
             String[] situation = br.readLine().split(" ");
-            String bigO = situation[0];
-            BigInteger inputLength = new BigInteger(situation[1]);
-            BigInteger executeCount = new BigInteger(situation[2]);
-            BigInteger timeLimit = BigInteger.valueOf(Integer.parseInt(situation[3]) * 100000000);
 
-            if (bigO.equals("O(N)")) {
-                if (inputLength.multiply(executeCount).compareTo(timeLimit) == 1) {
-                    bw.write(FAIL);
-                    continue;
-                }
-            } else if (bigO.equals("O(N^2)")) {
-                if (inputLength.pow(2).multiply(executeCount).compareTo(timeLimit) == 1) {
-                    bw.write(FAIL);
-                    continue;
-                }
-            } else if (bigO.equals("O(N^3)")) {
-                if (inputLength.pow(3).multiply(executeCount).compareTo(timeLimit) == 1) {
-                    bw.write(FAIL);
-                    continue;
-                }
-            } else if (bigO.equals("O(2^N)")) {
-                BigInteger base = new BigInteger("2");
-                if (base.pow(inputLength.intValue()).multiply(executeCount).compareTo(timeLimit) == 1) {
-                    bw.write(FAIL);
-                    continue;
-                }
+            if (isTimeout(situation)) {
+                bw.write("TLE!\n");
             } else {
-                int n = inputLength.intValue();
-
-                while (n-- > 1) {
-                    inputLength = inputLength.multiply(new BigInteger(Integer.toString(n)));
-                    if (inputLength.compareTo(timeLimit) == 1) {
-                        break;
-                    }
-                }
-
-                if (inputLength.multiply(executeCount).compareTo(timeLimit) == 1) {
-                    bw.write(FAIL);
-                    continue;
-                }
+                bw.write("May Pass.\n");
             }
 
-            bw.write("May Pass.\n");
         }
 
         bw.flush();
         bw.close();
+    }
+
+    private static boolean isTimeout(String[] inputs) {
+        String bigO = inputs[0];
+        BigInteger inputLength = new BigInteger(inputs[1]);
+        BigInteger executeCount = new BigInteger(inputs[2]);
+        BigInteger timeLimit = BigInteger.valueOf(Integer.parseInt(inputs[3]) * 100000000);
+
+        switch (bigO) {
+            case "O(N)":
+                if (inputLength.multiply(executeCount).compareTo(timeLimit) == 1) {
+                    return true;
+                }
+                break;
+            case "O(N^2)":
+                if (inputLength.pow(2).multiply(executeCount).compareTo(timeLimit) == 1) {
+                    return true;
+                }
+                break;
+            case "O(N^3)":
+                if (inputLength.pow(3).multiply(executeCount).compareTo(timeLimit) == 1) {
+                    return true;
+                }
+                break;
+            case "O(2^N)":
+                if (BigInteger.valueOf(2).pow(inputLength.intValue()).multiply(executeCount)
+                        .compareTo(timeLimit) == 1) {
+                    return true;
+                }
+                break;
+            case "O(N!)":
+                int n = inputLength.intValue();
+
+                while (n-- > 1) {
+                    inputLength = inputLength.multiply(BigInteger.valueOf(n));
+
+                    if (inputLength.compareTo(timeLimit) == 1) {
+                        return true;
+                    }
+                }
+
+                if (inputLength.multiply(executeCount).compareTo(timeLimit) == 1) {
+                    return true;
+                }
+
+                break;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
# 백준 11332. 시간초과 #14 

[문제 링크](https://www.acmicpc.net/problem/11332)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
| Silver 4 | 25.995% |

## 설계
- 총 테스트 케이스 C
- 내부 입력 최대 범위 N
- 내부 테스트 케이스 횟수 T
- 내부 케이스 제한시간 L
### 시간 복잡도
C, 최대 100번. O(1)
### 공간 복잡도
- BigInteger를 사용했는데 내부적으로 int형 배열을 사용해서 큰 수를 저장할 수 있다.
- 정확히 배열을 어떻게 써서 저장하는지는 잘 모르겠지만 한 칸에 2^32 크기만큼 저장되는 것으로 보임. 따라서 공간 복잡도는 연산의 결과 값 / 2^32 개 😕
![image](https://user-images.githubusercontent.com/42017052/82202536-038f5000-993d-11ea-94be-df615dc5641a.png)
## 풀이
- 연산 횟수를 계산해서 L * 100000000번을 넘으면 TLE로 처리했다.
- 다만 팩토리얼의 경우 계산 횟수가 너무 많아질 수 있으므로, 중간에 L * 100000000 을 넘을 경우 계산은 중단하고 결과를 출력하도록 했다. 