### PR TITLE
풀이: 백준.11332.시간 초과

### DIFF
--- a/problems/baekjoon/11332/changi.cpp
+++ b/problems/baekjoon/11332/changi.cpp
@@ -1,0 +1,58 @@
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+void solution() {
+  string bigO;
+  long long N, tc, tl;
+  long long LIMIT = 100000000;
+
+  cin >> bigO >> N >> tc >> tl;
+
+  long long calcul = 1;
+
+  calcul = tc;
+  if (bigO == "O(N)") {
+    calcul *= N;
+  } else if (bigO == "O(N^2)") {
+    calcul *= N * N;
+  } else if (bigO == "O(N^3)") {
+    calcul *= N * N;
+    if (calcul <= LIMIT * tl) {
+      calcul *= N;
+    }
+  } else if (bigO == "O(2^N)") {
+    for (int i = 0; i < N && calcul <= LIMIT * tl; i++) {
+      calcul *= 2;
+    }
+  } else if (bigO == "O(N!)") {
+    for (int i = 1; i <= N && calcul <= LIMIT * tl; i++) {
+      calcul *= i;
+    }
+  }
+
+  if (calcul <= LIMIT * tl) {
+    cout << "May Pass.";
+  } else {
+    cout << "TLE!";
+  }
+  cout << "\n";
+}
+
+int main() {
+  ios_base ::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
+
+  int T;
+  cin >> T;
+
+  for (int t = 0; t < T; t++) {
+    solution();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# 11332. 시간초과

[링크](https://www.acmicpc.net/problem/11332)

|  난이도   | 정답률(\_%) |
| :-------: | :---------: |
| Silver IV |   26.009    |

## 설계

### 시간복잡도

입력받은 연산을 수행하면 된다.

그러나 연산이 Time Limit를 초과하는 경우가 생길 수 있으므로 곱 등의 연산은 중간중간 TL check를 수행해야한다.

테스트케이스는 최대 100까지, 문제 내부 테스트케이스 T는 최대 10 까지이다.

연산의 수 N은 최대 1,000,000 까지이다.

최악의 경우 2^N을 구할 때 시간복잡도는 30 이다.

(log_2(1000000000) < 30 이고, 1,000,000,000 < 13 ! 이기 때문)

따라서 최악의 경우 총 시간복잡도는

```cpp
// 총 테스트케이스 * 내부 테스트케이스 * 하나의 내부 케이스의 최악의 연산
O(100 * 10 * 30) = 30,000
```

이므로 제한시간 2초 내에 가능하다.

### 공간 복잡도

2^N 또는 N!연산을 수행할 때 long long 의 범위를 초과하는 경우가 발생한다.

따라서 연산을 수행할 때마다 checking을 해줄 필요가 있다.

### 연산

내부 테스트케이스의 수만큼 반복하므로 각 시간복잡도에 테스트케이스의 수를 곱해야한다.

주어진 제약조건에서 long long 의 범위를 초과할 수 있는 경우는 다음과 같다.

- N^3 : 1,000,000 ^ 3 이면 초과
- N!
- 2^N

각 경우 미리 예외처리를 수행해야 한다.

```cpp
// "O(N^3)"
calcul *= N * N;
if (calcul <= LIMIT * tl) {
  calcul *= N;
}

// "O(2^N)")
for (int i = 0; i < N && calcul <= LIMIT * tl; i++) {
  calcul *= 2;
}

// bigO == "O(N!)"
for (int i = 1; i <= N && calcul <= LIMIT * tl; i++) {
  calcul *= i;
}
```

여기서 N^3을 구할 때 N^2는 long long 범위를 초과하지 않음에 유의한다.

이후 계산한 시간복잡도가 시간제한을 초과하는지 검사하면된다.

## 정리

| 내 코드 (ms) | 빠른 코드 (ms) |
| :----------: | :------------: |
|      0       |       0        |

## 고생한 점
