### PR TITLE
풀이: 백준.10989.수 정렬하기 3

### DIFF
--- a/problems/baekjoon/10989/changi.cpp
+++ b/problems/baekjoon/10989/changi.cpp
@@ -1,0 +1,40 @@
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+int table[10001];
+void solution() {
+  int N;
+  cin >> N;
+
+  int max = 0;
+  int temp;
+  for (int i = 0; i < N; i++) {
+    cin >> temp;
+    table[temp]++;
+    if (temp > max) {
+      max = temp;
+    }
+  }
+
+  for (int i = 0; i < max + 1; i++) {
+    for (int j = 0; j < table[i]; j++) {
+      cout << i << "\n";
+    }
+  }
+
+  cout << "\n";
+}
+
+int main() {
+  ios_base ::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
+
+  solution();
+
+  return 0;
+}


### PR DESCRIPTION
# 10989. 수 정렬하기 3

[링크](https://www.acmicpc.net/problem/10989)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
| Silver IV |     23     |

## 정리

### 시간 복잡도

N이 10,000,000 까지이므로 매우 크다.

이 경우 NlogN의 시간복잡도로는 풀이가 힘들다.

따라서 카운팅 정렬을 이용한다.

이 경우 시간복잡도는 O(2N)이다.

### 공간 복잡도

숫자의 범위는 1~10,000 까지 이므로 10001 크기의 정수형 배열을 생성한다.

N개의 수가 모두 같은 경우 하나의 index의 10,000,000이 할당되는데 이는 int형으로 충분하다.

### 카운팅 정렬

입력받는 수에 대한 테이블을 만들고, 입력받을 때마다 해당 테이블 번째의 count를 증가.

입력이 완료된 후 테이블을 순회하며 출력한다.
