### PR TITLE
Update: PR Trigger 삭제

### DIFF
--- a/.github/workflows/mergeMonday.yml
+++ b/.github/workflows/mergeMonday.yml
@@ -1,8 +1,5 @@
 name: mergeonMondy
 on:
-  pull_request:
-    branches:
-      - master
   schedule:
     - cron: "0 0 * * MON"
 jobs:


### PR DESCRIPTION
- 트리거가 스케줄, PR로 되어있어 기존 상태라면 원래 PR 이벤트에도 머지되어야함
- 찾아보니 automerge 라벨이 있어야 자동머지한다고해서 라벨링하고 테스트해봄
- PR에 해당 라벨을 달면 바로 자동 머지되는 것 확인 (#48)
- 우리 목적은 월요일마다 자동 머지 되는 것이기 때문에 PR 트리거는 삭제함..!