### PR TITLE
Add juno/boj/7576

### DIFF
--- a/problems/baekjoon/7576/junow.py
+++ b/problems/baekjoon/7576/junow.py
@@ -1,0 +1,42 @@
+from sys import stdin
+from collections import deque
+
+dy = [-1,0,1,0]
+dx = [0,1,0,-1]
+
+MAX=1000
+M, N = map(int, stdin.readline().split())
+q = deque()
+
+board = [list(map(int, stdin.readline().split())) for _ in range(N)]
+  
+for i in range(N):
+  for j in range(M):
+    if board[i][j] == 1:
+      q.append((i,j))
+
+def bfs():
+  ret=0
+
+  while(q):
+    y, x = q.popleft()
+
+    for dir in range(4):
+      ny = y + dy[dir]
+      nx = x + dx[dir]
+
+      if ny < 0 or nx < 0 or ny >= N or nx >= M: continue
+      if board[ny][nx] != 0: continue
+
+      board[ny][nx] = board[y][x] + 1
+      q.append((ny, nx))
+
+
+  for i in range(N):
+    if 0 in board[i]:
+      return -1;
+    ret = max(ret, max(board[i]))
+
+  return ret-1;
+
+print(bfs())


### PR DESCRIPTION
# 7576. 토마토

[링크](https://www.acmicpc.net/problem/7576)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Silver I |   31.731%   |

## 설계

1. 입력받으면서 익은 토마토(1) 을 deque 에 쌓는다.
2. deque 에서 토마토를 하나씩 꺼내서 주변에 있는 안익은 토마토(0) 에게 옮겨간다.
   - 0이 아닌 인경우는 무시함 (토마토 없는 곳 or 이미 익은 곳)
   - 안익은 토마토에게는 (현재 토마토에 써있는 숫자 + 1) 을 써준다. (익은 날짜 표기)
3. deque 이 빌떄까지 2번 반복
4. 완성된 토마토맵에서 (제일큰 숫자-1) 이 다 익는데까지 걸린 시간

### 시간복잡도

O(N\*M)

### 공간복잡도

O(N\*M)

### 자료구조

deque, array

## 고생한 점

- https://www.acmicpc.net/board/view/38423#comment-70882
- queue.Queue는 멀티스레딩을 위한 큐라서 매우 느리고, BOJ처럼 단순 자료구조로서의 큐를 쓰려면 collections.deque를 써야 합니다.
- queue.Queue 는 TLE 납니다.

for 문 활용에 따른 시간차이

기존코드 속도는 2500 ms 언저리가 나왔습니다.
1800 ms 짜리 다른 사람 코드를 참고해보니 저랑 로직은 같은데 사소한 부분이 조금씩 다르더군요.
그래서 코드를 조금씩 고쳐가며 시간이 어떻게 줄어드는지 알아봤습니다.

```python
board = [[]] * N
q = deque()

for y in range(N):
board[y] = list(map(int, input().split(' ')))

# 아래처럼 바꾸었을때 160 ms 정도 향상

board = [list(map(int, stdin.readline().split())) for _ in range(N)]
```

```python
for i in range(N):
   for j in range(M):
      if board[i][j] == 0: return -1;
      ret = max(ret, board[i][j])

# 아래처럼 바꾸었을 때 300mx 향상

for i in range(N):
      if 0 in board[i]:
         return -1;
      ret = max(ret, max(board[i]))
```

- 나만의 결론
  > 파이썬에서 for 를 이용해서 구문을 반복해주면 속도상 이점이 있다. 고수들의 코드를 보면 그런 이상한 코드들이 많은데 하나씩 보고 따라해봐야겠다.
