### PR TITLE
junow/boj/2630 색종이 만들기

### DIFF
--- a/problems/baekjoon/2630/junow.py
+++ b/problems/baekjoon/2630/junow.py
@@ -1,0 +1,38 @@
+from sys import stdin, setrecursionlimit
+
+# setrecursionlimit(10000)
+
+
+def check(sy, ey, sx, ex):
+  color = board[sy][sx]
+  for i in range(sy, ey+1):
+    for j in range(sx, ex+1):
+      if board[i][j] != color:
+        return False
+  return True
+
+
+def dfs(sy, ey, sx, ex):
+  if sy == ey or check(sy, ey, sx, ex):
+    ans[board[sy][sx]] += 1
+    return
+  else:
+    my = (sy+ey)//2
+    mx = (sx+ex)//2
+    dfs(sy, my, sx, mx)
+    dfs(sy, my, mx+1, ex)
+    dfs(my+1, ey, sx, mx)
+    dfs(my+1, ey, mx+1, ex)
+
+
+if __name__ == '__main__':
+  ans = [0, 0]
+  N = int(stdin.readline())
+  board = []
+  for _ in range(N):
+    board.append(list(map(int, stdin.readline().split())))
+
+  dfs(0, N-1, 0, N-1)
+
+  print(ans[0])
+  print(ans[1])


### PR DESCRIPTION
# 2630. 색종이 만들기

[링크](https://www.acmicpc.net/problem/2630)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   72.153%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    29380    |    72     |

## 설계

문제 그대로 사각형을 4등분해서 각 사분면 마다 모두 같은 색을 가졌는지 체크함.

### 시간복잡도

logN/log4 개의 사각형 마다 (N/logN/log4)^2 번의 비교연산?

O(logN/log4 \* (N/logN/log4)^2)

O(N^2 / logN / log4)

### 공간복잡도

### 자료구조

2차원 배열

## 고생한 점

복잡한 연산은 아니지만 수행시간에 영향을 끼치는 것

```python
dfs(sy, (sy+ey)//2, sx, (sx+ex)//2)
dfs(sy, (sy+ey)//2, (sx+ex)//2+1, ex)
dfs((sy+ey)//2+1, ey, sx, (sx+ex)//2)
dfs((sy+ey)//2+1, ey, (sx+ex)//2+1, ex)

# 불필요한 반복계산 제거
# 아래로 바꾸고 4ms 향상
# 88ms -> 83ms
my = (sy+ey)//2
mx = (sx+ex)//2
dfs(sy, my, sx, mx)
dfs(sy, my, mx+1, ex)
dfs(my+1, ey, sx, mx)
dfs(my+1, ey, mx+1, ex)
```

```python
isOne, color = check(sy, ey, sx, ex)
if isOne:
  ans[color] += 1
  return

# 미리답을 알 수 있을 때 dfs 진행 안함
# 아래로 바꾸고 12ms 향상
# 84ms -> 72ms
def dfs(sy, ey, sx, ex):
  if sy == ey or check(sy, ey, sx, ex):
    ans[board[sy][sx]] += 1
    return
```
