### PR TITLE
junow/boj/11729 하노이탑 이동 순서

### DIFF
--- a/problems/11729/junow.py
+++ b/problems/11729/junow.py
@@ -1,0 +1,28 @@
+from sys import stdin
+
+N = int(stdin.readline())
+memo = {}
+
+
+def hanoi(n, s, e):
+  if (n, s, e) in memo:
+    return memo[(n, s, e)]
+  if n == 1:
+    return '%d %d\n' % (s, e)
+
+  r = s ^ e
+
+  t1 = hanoi(n-1, s, r)
+  memo[(n-1, s, r)] = t1
+  t2 = '%d %d\n' % (s, e)
+  t3 = hanoi(n-1, r, e)
+  memo[(n-1, r, e)] = t3
+
+  return t1 + t2 + t3
+
+
+ans = hanoi(N, 1, 3)
+
+
+print(2**N-1)
+print(ans)


### PR DESCRIPTION
# 11729. 하노이 탑 이동 순서

[링크](https://www.acmicpc.net/problem/11729)

|  난이도   | 정답률(\_%) |
| :-------: | :---------: |
| Silver II |   48.589%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    47608    |    72     |

## 설계

흔히 알고 있는 하노이탑 횟수는 An = 2\*An-1 + 1 이고 이를 이용해서 문제풀이

```python
hanoi(n, s, e) # n 개의 블록을 s 에서 e 로 이동한다.

r = s^e # 시작점, 도착점을 제외한 나머지 한곳

hanoi(n, s, e) = hanoi(n-1, s,r) + (s, e) + hanoi(n-1, r, e)

```

메모이제이션 넣고 620 -> 72 로 향상

```python
memo = {} # dictionary 의 키값은 (n,s,e) 형태의 튜플, [n,s,e] 나 {n,s,e} 는 키값으로 사용 불가능

# 메모저장
t1 = hanoi(n-1, s, r)
memo[(n-1, s, r)] = t1
t2 = '%d %d\n' % (s, e)
t3 = hanoi(n-1, r, e)
memo[(n-1, r, e)] = t3

# 캐시히트
if (n, s, e) in memo:
  return memo[(n, s, e)]
```

### 시간복잡도

O(2^N)

### 공간복잡도

### 자료구조

- dictionary
- tuple

## 고생한 점

딕셔너리에는 배열이나 딕셔너리가 키값으로 들어갈 수 없다.

고차원의 키를 저장할 때는 튜플을 이용하자

```python
mamo = {}
memo[[1,2,3]] = 1 # typeError: unhashable type: 'list'
memo[{1,2,3}] = 1 # typeError: unhashable type: 'set'
memo[(1,2,3)] = 1 # ok
memo[1,2,3] = 1 # ok
```
