### PR TITLE
풀이: 백준.9095.1, 2, 3 더하기

### DIFF
--- a/problems/baekjoon/9095/changi.cpp
+++ b/problems/baekjoon/9095/changi.cpp
@@ -1,0 +1,54 @@
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+int dp[11];
+int limit;
+
+void dfs(int n, int sum) {
+  if (sum > 10) {
+    return;
+  }
+  if (n == limit) {
+    dp[sum] += 1;
+    return;
+  }
+
+  dfs(n + 1, sum + 1);
+  dfs(n + 1, sum + 2);
+  dfs(n + 1, sum + 3);
+}
+
+void init() {
+  for (int i = 1; i <= 10; i++) {
+    limit = i;
+    dfs(0, 0);
+  }
+}
+
+void solution() {
+  int N;
+  cin >> N;
+
+  cout << dp[N] << "\n";
+}
+
+int main() {
+  ios_base ::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
+
+  int T;
+  cin >> T;
+
+  init();
+  for (int t = 0; t < T; t++) {
+    solution();
+  }
+  // solution();
+
+  return 0;
+}


### PR DESCRIPTION
# 9095. 1, 2, 3 더하기

[링크](https://www.acmicpc.net/problem/9095)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   61.642    |

## 설계

### 시간복잡도

N은 최대 10까지이고, 테스트케이스의 수는 주어져있지 않다.

문제의 풀이 방법은 다음 두가지이다.

- 브루트 포스
- 다이나믹 프로그래밍

브루트 포스 방법으로 모든 경우의 수를 구한다고 가정하자.

숫자 1을 10번 더하면 10이 되므로, dfs로 최대 깊이 10까지 탐색을 돌린다. 시간복잡도는 최대 3^10보다 작으며 이는 59,049 이므로 1초 내에 충분하다.

중간에 더한 값이 10을 초과하는 경우는 필요하지 않으므로 back tracking 한다면 시간복잡도는 이보다 더 줄어든다.

다이나믹 프로그래밍으로 구하는 경우 시간복잡도는 N까지이므로 10이다. 이 또한 제한시간 내에 충분하다.

즉 두가지 방법 모두 사용 가능하다.

### 브루트포스

탐색을 위한 dfs함수는 다음과 같이 구현한다.

```cpp
void dfs(int n, int sum) {
  if (sum > 10) {
    return;
  }
  if (n == limit) {
    dp[sum] += 1;
    return;
  }

  dfs(n + 1, sum + 1);
  dfs(n + 1, sum + 2);
  dfs(n + 1, sum + 3);
}
```

현재 단계에서 숫자 1,2,3 셋중 하나를 선택할 수 있으므로 3번 자기자신을 호출하는 구조이다.

또한 sum을 기준으로 10을 초과한 경우 back tracking을 수행한다.

숫자를 1~10개 까지 고를 수 있으므로, dfs를 다음과 같이 호출한다.

```cpp
for (int i = 1; i <= 10; i++) {
  limit = i;
  dfs(0, 0);
}
```

### 일반항

1을 만드는 방법은 1가지, 2를 만드는 방법은 2가지, 3을 만드는 방법은 4가지 이다.

n이 다음과 같을 때를 살펴보자.

```cpp
n = 4
1 + 3   // 1의 경우의 수에 3을더함
2 + 2   // 2의 경우의 수에 2를더함
3 + 1   // 3의 경우의 수에 1을더함

n = 5
1 + 4   // 1의 경우의 수에 4를 더함
2 + 3   // 2의 경우의 수에 3을 더함
3 + 2   // 3의 경우의 수에 2를 더함
4 + 1   // 4의 경우의 수에 1을 더함
```

여기서 더할 수 있는 수는 1,2,3 뿐이므로 다음 조건이 성립한다.

```cpp
n = n
(n-3) + 3   // n-3인 경우의 수에 3을 더함
(n-2) + 2   // n-2인 경우의 수에 2을 더함
(n-1) + 1   // n-1인 경우의 수에 1을 더함
```

즉 n을 만드는 방법은 (n-3)을 만드는 경우의 수 + (n-2)을 만드는 경우의 수 + (n-1)을 만드는 경우의 수 이다.

```cpp
dp[n] = dp[n-3] + dp[n-2] + dp[n-1]
```

### 예시 데이터

```cpp
1 : 1
2 : 2
3 : 4
4 : 7
5 : 13
6 : 24
7 : 44
8 : 81
9 : 149
10 : 274
```

## 정리

| 내 코드 (ms) | 빠른 코드 (ms) |
| :----------: | :------------: |
|      0       |       0        |

## 고생한 점
