### PR TITLE
junow/boj/9095 1, 2, 3 더하기

### DIFF
--- a/problems/baekjoon/9095/junow.cpp
+++ b/problems/baekjoon/9095/junow.cpp
@@ -1,0 +1,31 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int T, N, ans;
+
+void dfs(int n) {
+  if (n == 0) {
+    ans++;
+    return;
+  }
+
+  for (int i = 1; i <= 3; i++) {
+    if (n - i >= 0) {
+      dfs(n - i);
+    }
+  }
+}
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  cin >> T;
+  while (T--) {
+    cin >> N;
+    ans = 0;
+    dfs(N);
+    cout << ans << "\n";
+  }
+  return 0;
+}


### PR DESCRIPTION
# 9095. 1, 2, 3 더하기

[링크](https://www.acmicpc.net/problem/9095)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   61.695%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1984     |     0     |

## 설계

N 부터 시작하여 dfs 로 1,2,3 씩 깍아서 진행.
base condition 은 N 0 이 되는 순간이다.

dp 를 활용하지 않아서 시간초과가 우려됬지만 n 이 워넉 작아 가능한듯.

### 시간복잡도

(logN/log3) \* N

### 공간복잡도

### 자료구조
배열
## 고생한 점
