### PR TITLE
junow/boj/2512 예산 질문

### DIFF
--- a/problems/baekjoon/2512/junow.cpp
+++ b/problems/baekjoon/2512/junow.cpp
@@ -1,0 +1,46 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+
+int N, M, a[10000], maxv;
+
+ll getSum(int m) {
+  ll ret = 0;
+  for (int i = 0; i < N; i++) {
+    if (a[i] <= m) {
+      ret += a[i];
+    } else {
+      ret += m;
+    }
+  }
+  return ret;
+}
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cin >> N;
+  for (int i = 0; i < N; i++) {
+    cin >> a[i];
+    maxv = max(maxv, a[i]);
+  }
+  cin >> M;
+
+  int l = 0;
+  int r = maxv;
+  while (l <= r) {
+    int m = (l + r) / 2;
+    ll sum = getSum(m);
+    if (sum <= M) {
+      l = m + 1;
+    } else {
+      r = m - 1;
+    }
+  }
+
+  cout << r << "\n";
+  return 0;
+}


### PR DESCRIPTION
# 2512. 예산

[문제링크](https://www.acmicpc.net/problem/)

|   난이도   | 정답률(\_%) |
| :--------: | :---------: |
| Silver III |   31.044%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    2024     |     0     |

## 설계

- long long 은 예산을 다 더해볼때만 잡아주면 된다. 나머지는 int 를 벗어나지 않음.
- 0 부터 최대 예산 까지 보면서 중간값을 예산으로 잡았을때, 전체 예산 합계가 최대 예산 가능값보다 작으면 오른쪽 탐색 크다면 왼쪽 탐색... 반복합니다.

## 질문

- 처음에 l 값을 최소 예산값으로 잡았을때 틀려서 그냥 0 으로 잡으니까 통과했는데요. 사실 그 이유를 잘 모르겠습니다.
- minv 는 예산중 최소값, maxv 는 예산중 최대값 입니다.
- 제 생각엔 탐색을 minv 부터 시작해도 맞을것 같은데요. 예제에서 110 이 최소값인데 100을 임의 예산으로 잡는다 해도 110 보다 작은 예산은 어차피 한푼도 배정해주지 못하기 때문에 while 안에 있는 if 문에 의해서 다시 minv 값보다 큰 범위내로 들어올 것이기 때문입니다.
- 혹시 제가 생각치 못한 인풋에서 잘못 동작할 수 있을까요?

```c
// 맞음
int l = 0;
int r = maxv;
while (l <= r) {
  int m = (l + r) / 2;
    ll sum = getSum(m);
    if (sum <= M) {
      l = m + 1;
    } else {
      r = m - 1;
    }
}
// 틀림
int l = minv;
int r = maxv;
while (l <= r) {
  int m = (l + r) / 2;
    ll sum = getSum(m);
    if (sum <= M) {
      l = m + 1;
    } else {
      r = m - 1;
    }
}
```

### 시간복잡도

O(NlogN)
