### PR TITLE
풀이: 백준.2805.나무 자르기

### DIFF
--- a/problems/baekjoon/2805/changi.cpp
+++ b/problems/baekjoon/2805/changi.cpp
@@ -1,0 +1,71 @@
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+vector<int> trees;
+
+long long calcul(int height) {
+  long long answer = 0;
+
+  for (int i = 0; i < trees.size(); i += 1) {
+    if (trees[i] > height) {
+      answer += trees[i] - height;
+    }
+  }
+
+  return answer;
+}
+
+void solution() {
+  int N, M;
+  int start = 0, end = 0, mid;  // using at binary search
+  int temp;
+  int answer = 0;
+  long long answer_length = -1;
+
+  cin >> N >> M;
+
+  for (int i = 0; i < N; i++) {
+    cin >> temp;
+    trees.push_back(temp);
+
+    if (end < trees[i]) end = trees[i];
+  }
+
+  start = 0;
+
+  while (end - start >= 0) {
+    mid = (start + end) / 2;
+    long long current_length = calcul(mid);
+
+    if (current_length >= M) {
+      if (current_length < answer_length || answer_length == -1) {
+        answer = mid;
+        answer_length = current_length;
+      }
+
+      // backtracking
+      if (answer_length - M == 0) {
+        break;
+      }
+      start = mid + 1;
+    } else {
+      end = mid - 1;
+    }
+  }
+
+  cout << answer << "\n";
+}
+
+int main() {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
+
+  solution();
+
+  return 0;
+}


### PR DESCRIPTION
# 2805. 나무 자르기

[링크](https://www.acmicpc.net/problem/2805)

|   난이도   | 정답률 (\_%) |
| :--------: | :----------: |
| Silver III |      25      |

## 설계

### 이분 탐색

0부터 max(입력받은 나무들 중 최고 길이) 까지 하나하나 검사할 경우 시간초과가 난다.

따라서 이분탐색으로 구현을 해야한다.

1. 잘라야 하는 나무의 기준점 M
2. 현재 톱의 높이를 h
3. 톱의 높이가 h일때 자른 나무의 길이를 반환하는 함수를 cal(h)
4. 이분 탐색의 시작과 끝점 start, end

라고 할때 이분 탐색의 조건은 다음과 같다.

- cal(h) > M
  - 정답을 갱신한다
  - cal(h)를 M에 최적화 해야 하기 위해선 h를 증가시켜야한다.
  - start = mid + 1
- cal(h) == M
  - 가능한 최적의 해이다
  - 이 경우 탐색을 종료한다 (backtracking)
- cal(h) < M
  - h를 낮추어 cal(h)를 증가시켜야 한다
  - end = mid -1

### 자른 나무의 길이 구하기

나무를 정렬하던 정렬하지 않던, 나무의 길이를 자르기 위해서는 시간복잡도 (N)이 필요하다.

## 정리

| 내 코드 | 빠른 코드 |
| :-----: | :-------: |
| 164 ms  |    40     |

## 고생한 점

### 이분 탐색의 조건 생각하기

처음 구현한 코드는 이분 탐색의 조건이 완전히 반대로였다.

나무를 자르는 것에 최적화 하는것이 헷갈리기 때문이다.