### PR TITLE
junow boj 1941 소문난 칠공주

### DIFF
--- a/problems/baekjoon/1941/junow.cpp
+++ b/problems/baekjoon/1941/junow.cpp
@@ -1,0 +1,80 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+char board[5][5];
+bool visit[5][5];
+int perm[5][5];
+
+bool isInRange(int x, int y) {
+  return min(x, y) >= 0 && max(x, y) < 5;
+}
+
+int dfs(int x, int y) {
+  visit[x][y] = true;
+  int ret = 1;
+  for (int dir = 0; dir < 4; dir++) {
+    int nx = x + dx[dir];
+    int ny = y + dy[dir];
+    if (!isInRange(ny, nx)) continue;  // 범위안에 있는지
+    if (visit[nx][ny]) continue;       // 이미 방문했는지
+    if (!perm[nx][ny]) continue;       // 해당 지점 갈 수 있는지
+
+    ret += dfs(nx, ny);
+  }
+  return ret;  // 방문한 지점 리턴;
+}
+
+void input() {
+  for (int i = 0; i < 5; i++) {
+    cin >> board[i];
+  }
+}
+
+int solve() {
+  int ans = 0;
+  vi selected(25, 0);
+  for (int i = 0; i < 7; i++) {
+    selected[24 - i] = 1;
+  }
+
+  do {
+    fill(&perm[0][0], &perm[4][4], 0);
+    int y_cnt = 0;
+    int sx, sy;
+    for (int i = 0; i < 25; i++) {
+      int x = i / 5;
+      int y = i % 5;
+      perm[x][y] = selected[i];
+      if (selected[i]) {
+        sx = x;
+        sy = y;
+        y_cnt += board[x][y] == 'Y';
+      }
+    }
+    if (y_cnt >= 4) continue;
+    fill(&visit[0][0], &visit[4][4], 0);
+    ans += dfs(sx, sy) == 7;
+  } while (next_permutation(selected.begin(), selected.end()));
+
+  return ans;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  input();
+
+  cout << solve() << endl;
+  return 0;
+}


### PR DESCRIPTION
# 1941. 소문난 칠공주

[문제링크](https://www.acmicpc.net/problem/1941)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Gold III |   45.132%   |

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    1984     |    76     |

## 설계

입력이 작기 때문에 모든 경우를 다 봐도 된다.

일단 `next_permutation` 으로 25개의 점중 7개를 뽑는 모든 경우의 수를 찾는다.

각 경우에서 갈 수 있는 지점을 표시하고 그 과정에서 'Y' 의 개수를 세서 4 개 이상이면 그만둔다. (가지치기?)

마지막으로 dfs 를 돌려서 7개의 지점을 찍고 돌아온다면 가로나 세로로 모두 인접해 있다는 뜻. `ans++`

### 시간복잡도
25C7 * 25