### PR TITLE
풀이: 백준.1941.소문난 칠공주

### DIFF
--- a/problems/baekjoon/1941/changi.cpp
+++ b/problems/baekjoon/1941/changi.cpp
@@ -1,0 +1,99 @@
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <queue>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+struct Axis {
+  int y, x;
+};
+
+Axis dirs[4] = {{-1, 0}, {0, 1}, {1, 0}, {0, -1}};
+bool board[5][5];
+int answer = 0;
+
+bool isLinked(vector<Axis> choose) {
+  bool checked[5][5] = {
+      false,
+  };
+  bool visited[5][5] = {
+      false,
+  };
+  int visited_count = 0;
+
+  for (Axis cur : choose) {
+    checked[cur.y][cur.x] = true;
+  }
+
+  queue<Axis> q;
+  q.push(choose.front());
+
+  while (!q.empty()) {
+    Axis cur = q.front();
+    q.pop();
+
+    if (visited[cur.y][cur.x]) continue;
+    visited_count += 1;
+    visited[cur.y][cur.x] = true;
+
+    for (Axis dir : dirs) {
+      Axis next = cur;
+      next.x += dir.x;
+      next.y += dir.y;
+      if (0 > next.x || 5 <= next.x || 0 > next.y || 5 <= next.y) continue;
+      if (!checked[next.y][next.x]) continue;
+
+      q.push(next);
+    }
+  }
+
+  if (visited_count == 7) return true;
+  return false;
+}
+
+void dfs(int index, vector<Axis> choose, int enemy) {
+  if (enemy > 3) return;
+  if (choose.size() == 7) {
+    if (isLinked(choose)) {
+      answer += 1;
+    }
+    return;
+  }
+  if (index == 25) return;
+
+  Axis cur = {index / 5, index % 5};
+  index += 1;
+
+  dfs(index, choose, enemy);
+  choose.push_back(cur);
+  dfs(index, choose, board[cur.y][cur.x] ? enemy : enemy + 1);
+}
+
+void solution() {
+  string line;
+
+  for (int y = 0; y < 5; y++) {
+    cin >> line;
+    for (int x = 0; x < 5; x++) {
+      board[y][x] = line[x] == 'S' ? true : false;
+    }
+  }
+
+  vector<Axis> choose;
+  dfs(0, choose, 0);
+
+  cout << answer << "\n";
+}
+
+int main() {
+  ios_base ::sync_with_stdio(false);
+  cin.tie(NULL);
+  cout.tie(NULL);
+
+  solution();
+
+  return 0;
+}


### PR DESCRIPTION
# 1941. 소문난 칠공주

[링크](https://www.acmicpc.net/problem/1941)

|  난이도  | 정답률(\_%) |
| :------: | :---------: |
| Gold III |   45.173    |

## 설계

### 시간 복잡도

2^25 번 탐색하며, 7개의 좌표를 고른다.

7개의 숫자를 고른 뒤에 각 좌표들이 서로 연결되어있는지 탐색한다.

탐색할 때는 BFS를 이용해 탐색하며, 7개의 지점이 모두 연결되어있는지 탐색한다.

```bash
2^25 * 7 = 33,554,432 * 7 = 234,881,024
```

이므로 backtracking을 적용하지 않으면 제한 시간 내에 불가능하다.

### 공간 복잡도

5^2 크기의 2차원 boolean 배열을 선언해 사용한다.

### backtracking

'임도연파'가 4명 이상인 경우는 조합이 불가능하다. 따라서 탐색을 진행하며 임도연파가 4명 이상인 경우에는 더 이상 탐색하지 않는다.

### 연결관계 확인

연결관계의 확인은 BFS를 이용해 진행한다.

7개의 좌표 중 한점을 시작점으로 잡고 BFS로 탐색한다.

모든 점을 방문한 경우 전부 연결되어있고, 방문하지 못한경우 연결되어있지 않다.

## 정리

| 내 코드 (ms) | 빠른 코드 (ms) |
| :----------: | :------------: |
|     144      |       0        |

## 고생한 점

맨 끝점일 때 link를 체크하지 않고 바로 return 해서 틀렸었다.