### PR TITLE
[질문] junow 주식가격

### DIFF
--- a/problems/programmers/42854/junow.cpp
+++ b/problems/programmers/42854/junow.cpp
@@ -1,0 +1,50 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+vector<int> solution(vector<int> prices) {
+  vector<int> answer;
+  stack<pii> s;
+  int curTime = 0, size = prices.size();
+  answer.resize(size, 0);
+
+  for (int i = 0; i < size; i++) {
+    curTime++;
+    if (s.empty() || prices[i] >= s.top().first) {
+      s.push({prices[i], curTime});
+    } else {
+      while (!s.empty() && s.top().first > prices[i]) {
+        auto out = s.top();
+        s.pop();
+        answer[out.second - 1] = curTime - out.second;
+      }
+      s.push({prices[i], curTime});
+    }
+  }
+
+  while (!s.empty()) {
+    auto out = s.top();
+    s.pop();
+    answer[out.second - 1] = curTime - out.second;
+  }
+  return answer;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  vi v = {1, 2, 3, 2, 3};
+  auto ans = solution(v);
+  for (auto& v : ans) cout << v << " ";
+  cout << endl;
+  return 0;
+}


### PR DESCRIPTION
# 42584. 주식가격

[문제링크](https://programmers.co.kr/learn/courses/30/lessons/42584)

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    3.8mb    |  0.02ms   |

## 설계

`prices`가 100000이라서 가장쉽게 생각해 볼 수 있는 `O(N^2)` 풀이로는 간당간당할 듯.

prices 배열을 이중 포문으로 돌지않고 현재값을 기준으로 이전값을 업데이트 하면 됨.

가격 하나를 보고 스택에 이미 들어있는 애들을 뺴는 횟수는 최소 0 회 최대 n 회 니까 대충 평균 잡으면 n/2 라고 하면.. `N*N/2 = O(N^2) ?? 엥`

스택을 활욜하고 `{가격, 현재시간}` 을 넣는다.

{1,1}, {2,2}, {3,3} 넣은 상태에서 {2,4} 를 넣기위해서는 일단 먼저들어갈 애들중에 2원을 보다 큰 애들은 모두 제거한다. 2원이 들어오는 순간 3원 이상인 애들은 모두 주식가격이 떨어지는 시간이기 떄문.

각 아이템이 떨어지는 시간을 기록할 공간의 인덱스는 아이템이 들어갈 떄의 `시간-1` 이 된다.

이런식으로 모든 `prices` 에 대해 처리하고 스택내에 남은 애들도 똑같은 방식으로 시간을 기록해준다.

### 시간복잡도

O(N^2)

## 질문 
이 문제처럼 `N^2` 까지는 아니지만 경우에 따라서 배열의 크기가 줄어들면서 이중 반복문 탐색을 한다면 시간복잡도는 어떻게 계산할 수 있을까요?
