### PR TITLE
junow 기능 개발

### DIFF
--- a/problems/programmers/42586/junow.cpp
+++ b/problems/programmers/42586/junow.cpp
@@ -1,0 +1,54 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+vector<int> solution(vector<int> progresses, vector<int> speeds) {
+  vector<int> answer;
+  queue<int> q;
+
+  for (int i = 0, size = progresses.size(); i < size; i++) {
+    int t = (100 - progresses[i]) / speeds[i] + 1;
+    if ((100 - progresses[i]) % speeds[i] == 0) t--;
+    q.push(t);
+  }
+
+  while (!q.empty()) {
+    auto cur = q.front();
+    int cnt = 1;
+    q.pop();
+
+    while (!q.empty() && q.front() <= cur) {
+      cnt++;
+      q.pop();
+    }
+
+    answer.push_back(cnt);
+  }
+
+  return answer;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+
+  vi progresses = {93, 30, 55};
+  vi speeds = {1, 30, 5};
+  vector<int> ans = solution(progresses, speeds);
+
+  for (auto& v : ans) {
+    cout << v << " ";
+  }
+  cout << endl;
+
+  return 0;
+}


### PR DESCRIPTION
# 42586. 기능개발

[문제링크](https://programmers.co.kr/learn/courses/30/lessons/42586)

| 메모리 (KB) | 시간 (ms) |
| :---------: | :-------: |
|    3.7mb    |  0.01ms   |

## 설계

n 이 100으로 매우작기 때문에 N^3 까지 커버가능

현재 작업 시간 기준으로 작거나 같은 애들을 모두 묶어 `queue` 에서 빼버리면 `O(N)` 에 처리가능

작업당 걸리는 일수: `(100 - progresses[i]) / speeds[i] + 1`

`(100 - progresses[i]) % speeds[i]` 이 나머지가 없다면 `+1` 해줄 필요없음

각 작업이 걸리는 일수를 `queue` 넣어두고 (앞 작업이 끝나는 날에 뒷 작업이 같이 배포되니까 앞에서 봐야함) 현재 값보다 작거나 같은 작업은 모두 현재 작업과 함께 배포. (`cnt` 개 만큼)

근데 남은 일수가 (2,4,1) 이면 첫날에 하나가 배포되는지 두개가 배포되는지 모르겠음.
현재 코드는 `1,2` 를 리턴하는데 정답임

### 시간복잡도

`O(N)`
