### PR TITLE
junow 외벽점검

### DIFF
--- a/problems/programmers/60062/junow.cpp
+++ b/problems/programmers/60062/junow.cpp
@@ -1,0 +1,75 @@
+#include <bits/stdc++.h>
+#define endl "\n"
+
+using namespace std;
+
+typedef long long ll;
+typedef vector<int> vi;
+typedef pair<int, int> pii;
+typedef vector<pair<int, int>> vpii;
+
+const int dy[4] = {-1, 0, 1, 0};
+const int dx[4] = {0, 1, 0, -1};
+
+int answer;
+int check(int start, int originWeakSize, vector<int>& weak, vector<int>& dist) {
+  int ret = 0;  // 탐색한 사람 수
+  int weak_idx = start;
+  int cnt = 0;  // 탐색한 취약지역 수
+  for (int dist_idx = 0; dist_idx < dist.size(); dist_idx++) {
+    int to = weak[weak_idx] + dist[dist_idx];
+    ret++;
+    if (ret >= answer) return ret;
+    while (to >= weak[weak_idx]) {
+      weak_idx++;
+      cnt++;
+      if (cnt == originWeakSize) return ret;
+    }
+  }
+  return INT_MAX;
+}
+
+int solution(int n, vector<int> weak, vector<int> dist) {
+  answer = INT_MAX;
+  int originWeakSize = weak.size();
+  for (int i = 0, size = weak.size() - 1; i < size; i++) {
+    weak.push_back(weak[i] + n);
+  }
+
+  sort(dist.begin(), dist.end());
+  for (int i = 0; i < originWeakSize; i++) {
+    do {
+      answer = min(answer, check(i, originWeakSize, weak, dist));
+    } while (next_permutation(dist.begin(), dist.end()));
+  }
+  if (answer == INT_MAX) {
+    return -1;
+  }
+  return answer;
+}
+
+int main(void) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  int n1 = 12;
+  vi weak1 = {1, 5, 6, 10};
+  vi dist1 = {1, 2, 3, 4};
+
+  int n2 = 12;
+  vi weak2 = {1, 3, 4, 9, 10};
+  vi dist2 = {3, 5, 7};
+
+  int n3 = 30;
+  vi weak3 = {0, 3, 11, 21};
+  vi dist3 = {10, 4};
+
+  int n4 = 50;
+  vi weak4 = {1};
+  vi dist4 = {6};
+  cout << solution(n1, weak1, dist1) << endl;
+  cout << solution(n2, weak2, dist2) << endl;
+  cout << solution(n3, weak3, dist3) << endl;
+  cout << solution(n4, weak4, dist4) << endl;
+
+  return 0;
+}


### PR DESCRIPTION
# 60062. 외벽점검

[문제링크](https://programmers.co.kr/learn/courses/30/lessons/60062?language=cpp)

| 난이도 | 정답률(\_%) |
| :----: | :---------: |
| level3 |    0.6%     |

## 설계

`dist` 가 최대 길이가 8 로 매우 작기 때문에 `8!` 개의 모든 순열을 조합해 볼 수 있다. 

점검을 왼쪽으로도, 오른쪽으로도 가능하기 때문에 `1,2,3` 이렇게 있으면 `1,2,3,4, N+1, N+2, N+3` 해서 생각해볼 수 있다. 2부터 반시계로 4까지 가는건 4 부터 n+2 까지 시계방향으로 가는것과 같다. 

그래서 `weak` 배열은 `2*N-1` 의 길이가 된다.

그래서 1 부터 4까지, 4 부터 N+3 까지 모두 탐색해보면 답을 찾을 수 있다. `dist` 배열은 `next_permutation` 으로 순열을 뽑아내서 각 취약지점을 각각의 친구들이 탐색했을때 몇명이 탐색했는지, 모두 탐색했는지 확인해 보면 된다.

`next_permutation` 을 쓰기위해 `dist` 배열을 정렬해두고 각 단계마다 함수를 실행한다.

함수안에서는 시작값을 받는데 이 시작값은 1 부터 4 까지다. 4에서 시작하는 탐색은 시간 반대 방향을 의미한다. 현재 위치에서 `dist[i]` 값으로 탐색이 가능한 범위를 정하고 코드에선 `int to = weak[weak_idx] + dist[dist_idx];` 에 해당한다. 

전체를 탐색한 경우는 `if (cnt == originWeakSize` 조건으로 확인 가능하다. (모든 취약지점을 탐색한 경우)
이 조건이 있기 때문에 `to >= weak[weak_idx]` 구문에서 out of range 에러를 방지할 수 있다. start 값이 최대 `N` 만큼만 들어오기 때문에 만약 `N` 에서 시작해서 `N` 개만큼 탐색할 경우 저 조건문에 걸리기 때문이다. 


### 시간복잡도

weak 길이: M, dist 길이: N 일때 

`O(N!*M)
